### PR TITLE
IT-204 -> Change Reference From slcpub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules
 # The reason we ignore the lock file is because we explicitly pin our
 # version in the package.json file.
-# Ultimately the reaeson we do that is because we pull in our @csmcentral
+# Ultimately the reason we do that is because we pull in our @csmcentral
 # packages as git repos and not from npm. The syntax of "csmcentral/<package-name>"
 # pulls in the latest version of the package from the default branch. 
 # If we had the lock file, it would pin the version to the last installed version

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 node_modules
+# The reason we ignore the lock file is because we explicitly pin our
+# version in the package.json file.
+# Ultimately the reaeson we do that is because we pull in our @csmcentral
+# packages as git repos and not from npm. The syntax of "csmcentral/<package-name>"
+# pulls in the latest version of the package from the default branch. 
+# If we had the lock file, it would pin the version to the last installed version
+# and not the latest version from the default branch.
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   "homepage": "https://github.com/csmcentral/gulp-alt-useref#readme",
   "main": "index.js",
   "dependencies": {
-    "gulp-concat": "^2.6.0",
-    "q": "^1.4.1",
-    "through2": "^3.0.1",
-    "useref": "^1.4.1",
-    "vinyl-fs": "^3.0.2"
+    "gulp-concat": "2.6.1",
+    "q": "1.5.1",
+    "through2": "3.0.2",
+    "useref": "1.4.4",
+    "vinyl-fs": "3.0.3"
   },
   "devDependencies": {
-    "gulp-debug": "^3.2.0"
+    "gulp-debug": "3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@slcpub/gulp-alt-useref",
-  "description": "Alternative to gulp-useref.",
+  "name": "@csmcentral/gulp-alt-useref",
+  "description": "This is a fork of @slcpub/gulp-alt-useref - Alternative to gulp-useref.",
   "version": "1.0.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/softlife/gulp-alt-useref.git"
+    "url": "https://github.com/csmcentral/gulp-alt-useref.git"
   },
-  "homepage": "https://github.com/softlife/gulp-alt-useref#readme",
+  "homepage": "https://github.com/csmcentral/gulp-alt-useref#readme",
   "main": "index.js",
   "dependencies": {
     "gulp-concat": "^2.6.0",
@@ -17,8 +17,5 @@
   },
   "devDependencies": {
     "gulp-debug": "^3.2.0"
-  },
-  "publishConfig": {
-    "@slcpub:registry": "https://gitlab.com/api/v4/projects/34256364/packages/npm/"
   }
 }


### PR DESCRIPTION
changed the package.json fields to point to csmcentral

## Linked PRs:
### Internal Tooling
- https://github.com/csmcentral/ServerFramework/pull/8
- https://github.com/csmcentral/repo-utils/pull/8
### Local Package References
- https://github.com/csmcentral/payments-js/pull/2
- https://github.com/csmcentral/CSMBooksWeb/pull/17
- https://github.com/csmcentral/CSMCommonWeb/pull/10
- https://github.com/csmcentral/PTAEZWeb/pull/7
### Libraries
- https://github.com/csmcentral/CSMBooks/pull/108
- https://github.com/csmcentral/CSMStore/pull/42
### Products
- https://github.com/csmcentral/ASBWorks/pull/85
- https://github.com/csmcentral/ASBStore/pull/21
- https://github.com/csmcentral/BoosterFinance/pull/21
- https://github.com/csmcentral/PTAEZ/pull/29
- https://github.com/csmcentral/CSMAdmin/pull/12
- https://github.com/csmcentral/PollingWorks/pull/26
- https://github.com/csmcentral/CommunityWebstore/pull/16
- https://github.com/csmcentral/PTAStore/pull/11
- https://github.com/csmcentral/BoosterStore/pull/10
### Packages
- https://github.com/csmcentral/angular-toastr/pull/1
- https://github.com/csmcentral/bower-main/pull/1
- https://github.com/csmcentral/csm-build-tools/pull/1
- https://github.com/csmcentral/SharedFiles/pull/5
- https://github.com/csmcentral/gulp-alt-useref/pull/1
- https://github.com/csmcentral/gulp-ng-templatecache-loader/pull/1
- https://github.com/csmcentral/gulp-npm/pull/1
- https://github.com/csmcentral/gulp-nuget/pull/1
- https://github.com/csmcentral/webspinner-ajs/pull/1
